### PR TITLE
PE-978: Upgrade Node.js to 24 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install --ignore-scripts
       - run: npm run prebuild
         env:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install --ignore-scripts
       - run: npm run prebuild-linux-x64
       - run: npm run prebuild-linux-arm64-glibc
@@ -48,7 +48,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install --ignore-scripts
       - run: npm run prebuild
       - run: tar --create --verbose --file=prebuild-windows.tar -C prebuilds .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install
       - run: npm test
   test-linux:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install
       - run: npm test
   test-windows:
@@ -28,6 +28,6 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install
       - run: npm test


### PR DESCRIPTION
## Summary

Upgrade Node.js version to 24 in GitHub Actions workflows as part of PE-978.

Node 20 reached EOL April 2026. Node 24 is Active LTS (EOL April 2029).

**Changed files:**
- `.github/workflows/prebuild.yml`
- `.github/workflows/test.yml`

> ⚠️ **Compatibility note:** node-lmdb is a native C++ addon. Node 24 requires recompiling the binding. Verify `binding.gyp` builds cleanly against Node 24 before merging.

## Test plan
- [ ] Verify prebuild workflow succeeds on Node 24
- [ ] Verify test workflow passes on Node 24
- [ ] Confirm native module compiles successfully